### PR TITLE
Relax bound of rank2classes to < 1.5

### DIFF
--- a/incremental-parser.cabal
+++ b/incremental-parser.cabal
@@ -30,7 +30,7 @@ Library
                      Text.ParserCombinators.Incremental.LeftBiasedLocal, Text.ParserCombinators.Incremental.Symmetric,
                      Control.Applicative.Monoid
   Build-Depends:     base >= 4.9 && < 5, transformers >= 0.5 && < 0.6, parsers < 0.13,
-                     monoid-subclasses < 1.1, rank2classes >= 1.0 && < 1.4
+                     monoid-subclasses < 1.1, rank2classes >= 1.0 && < 1.5
   ghc-options:       -Wall
   if impl(ghc >= 7.0.0)
      default-language: Haskell2010


### PR DESCRIPTION
With rank2classes 1.4 incremental-parser builds fine and all tests pass.