### PR TITLE
Allow monoid-subclasses 1.2 for the test suite

### DIFF
--- a/incremental-parser.cabal
+++ b/incremental-parser.cabal
@@ -39,7 +39,7 @@ test-suite Main
   Type:              exitcode-stdio-1.0
   x-uses-tf:         true
   Default-Language:  Haskell2010
-  Build-Depends:     base < 5, incremental-parser, monoid-subclasses < 1.2,
+  Build-Depends:     base < 5, incremental-parser, monoid-subclasses < 1.3,
                      QuickCheck >= 2 && < 3, checkers >= 0.3.2 && < 0.7,
                      tasty >= 0.7 && < 1.5, tasty-quickcheck >= 0.7 && < 1.0
   Main-is:           Test/TestIncrementalParser.hs


### PR DESCRIPTION
All tests pass with the new version.